### PR TITLE
Prune intermeidate build & make logs accesable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # First, create an image to build simulations
 #
 FROM python:3.10-slim AS build_image
+LABEL stage=artifact-builder
 
 # Install  packages required for build
 RUN apt-get update -y

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,13 +13,13 @@ Note that you don't need docker to test the app: see the `app` directory for ins
 
 From the directory that `Dockerfile` is in:
 ```
-docker build -t artefact/api .
+sudo docker build -t artefact/api . && sudo docker image prune --filter=label=stage=artifact-builder -f
 ```
 This builds an image called `artefact/api` using the Dockerfile at `.`.
 
-Now run, and map host port 5000 to the container's port 80:
+Now run, and map host port 4242 to the container's port 80:
 ```
-docker run -it --rm -p 5000:80 artefact/api
+sudo docker run -it --rm -p 4242:80 artefact/api
 ```
 
 Then, in another terminal, on the host machine:
@@ -38,10 +38,21 @@ docker build -t artefact/api .
 docker system prune -f
 ```
 
-TODO: SOMEHOW RUN THIS, BUT ROUTE STDOUT AND STDERR TO /VAR/LOG/VCLAMP, AND DAEMONIZE
+To be able to access logs set up a docker volume
+`sudo docker volume create artefact_logs`
+
+You can see where the data will be stored (the Mountpoint) by doing:
+`sudo docker volume inspect artefact_logs`
+
+To start the component (in detached mode):
 ```
-docker run -it --rm -p 5000:80 artefact/api
+docker run -d --always-restart -v artefact_logs:/var/log/gunicorn -p 4242:80 artefact/api
 ```
 
-TODO: SOMEHOW CONNECT OTHER SERVER TO THIS
+The API is now avaliable on http://localhost:4242 on the host machine you are running the docker component on. If this is a server, you might want to proxy this through the server's webserver. For example on cardiac.nottingham we have proied it through as `https://cardiac.nottingham.ac.uk/artefact-webapp/`
 
+This is achieved with the following config:
+`<Location /artefact-webapp>
+   ProxyPass http://localhost:4242
+   ProxyPassReverse http://localhost:4242
+</Location>`

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,8 +34,7 @@ If it works, this should print out a whole bunch of numbers.
 Build the image, and delete all stopped, dangling etc. things:
 
 ```
-docker build -t artefact/api .
-docker system prune -f
+sudo docker build -t artefact/api . && sudo docker image prune --filter=label=stage=artifact-builder -f
 ```
 
 To be able to access logs set up a docker volume

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,7 +49,7 @@ sudo docker volume inspect artefact_logs
 
 To start the component (in detached mode):
 ```
-docker run -d --always-restart -v artefact_logs:/var/log/gunicorn -p 4242:80 artefact/api
+sudo docker run -d --restart always -v artefact_logs:/var/log/gunicorn -p 4242:80 artefact/api
 ```
 
 The API is now avaliable on http://localhost:4242 on the host machine you are running the docker component on. If this is a server, you might want to proxy this through the server's webserver. For example on cardiac.nottingham we have proied it through as `https://cardiac.nottingham.ac.uk/artefact-webapp/`

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,10 +38,14 @@ sudo docker build -t artefact/api . && sudo docker image prune --filter=label=st
 ```
 
 To be able to access logs set up a docker volume
-`sudo docker volume create artefact_logs`
+```
+sudo docker volume create artefact_logs
+```
 
 You can see where the data will be stored (the Mountpoint) by doing:
-`sudo docker volume inspect artefact_logs`
+```
+sudo docker volume inspect artefact_logs
+```
 
 To start the component (in detached mode):
 ```
@@ -51,7 +55,9 @@ docker run -d --always-restart -v artefact_logs:/var/log/gunicorn -p 4242:80 art
 The API is now avaliable on http://localhost:4242 on the host machine you are running the docker component on. If this is a server, you might want to proxy this through the server's webserver. For example on cardiac.nottingham we have proied it through as `https://cardiac.nottingham.ac.uk/artefact-webapp/`
 
 This is achieved with the following config:
-`<Location /artefact-webapp>
+```
+<Location /artefact-webapp>
    ProxyPass http://localhost:4242
    ProxyPassReverse http://localhost:4242
-</Location>`
+</Location>
+```

--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -16,6 +16,6 @@ workers = 1
 threads = 2
 
 # Logging
-#accesslog = "/var/log/gunicorn/access.log"
-#errorlog = "/var/log/gunicorn/error.log"
-
+loglevel = "debug"
+accesslog = "/var/log/gunicorn/access.log"
+errorlog = "/var/log/gunicorn/error.log"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -7,4 +7,4 @@
 nginx
 touch /var/log/gunicorn/gunicorn.log
 chown vclamp:vclamp /var/log/gunicorn/gunicorn.log
-su vclamp -c "gunicorn --log-level debug --error-logfile /var/log/gunicorn/gunicorn.log app:app"
+su vclamp -c "gunicorn app:app"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,6 +5,4 @@
 # exit when the process is done).
 #
 nginx
-touch /var/log/gunicorn/gunicorn.log
-chown vclamp:vclamp /var/log/gunicorn/gunicorn.log
 su vclamp -c "gunicorn app:app"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,4 +5,6 @@
 # exit when the process is done).
 #
 nginx
-su vclamp -c "gunicorn app:app"
+touch /var/log/gunicorn/gunicorn.log
+chown vclamp:vclamp /var/log/gunicorn/gunicorn.log
+su vclamp -c "gunicorn --log-level debug --error-logfile /var/log/gunicorn/gunicorn.log app:app"


### PR DESCRIPTION
- changed the docker file to add a label and the instructions to prune the intermediate build only (using that label) rather than everything
- changed startup.sh to save to log
- added instructions to use a volume in order to be able to access log